### PR TITLE
fix: clientDeferred catch is not a function error

### DIFF
--- a/src/plugin/NextIntlWebpackPlugin.js
+++ b/src/plugin/NextIntlWebpackPlugin.js
@@ -24,7 +24,7 @@ export default class NextIntlWebpackPlugin {
     apply(compiler) {
         if (!this.isServer) {
             NextIntlWebpackPlugin.clientDeferred = pDefer();
-            NextIntlWebpackPlugin.clientDeferred.catch(() => {});
+            NextIntlWebpackPlugin.clientDeferred.promise.catch(() => {});
 
             compiler.hooks.failed.tap('NextIntlPlugin', (err) => {
                 NextIntlWebpackPlugin.clientDeferred.reject(err);


### PR DESCRIPTION
This PR aims to fix the `UnhandledPromiseRejectionWarning: TypeError: NextIntlWebpackPlugin.clientDeferred.catch is not a function` when using the lib.